### PR TITLE
Add user agent to curl to avoid 403

### DIFF
--- a/src/FakerPicsumImagesProvider.php
+++ b/src/FakerPicsumImagesProvider.php
@@ -79,11 +79,13 @@ class FakerPicsumImagesProvider extends BaseProvider
 
         // save file
         if (function_exists('curl_exec')) {
+             $user_agent = ini_get('user_agent') ? ini_get('user_agent') : 'Mozilla/5.0 (X11; Linux x86_64; rv:104.0) Gecko/20100101 Firefox/104.0"'
             // use cURL
             $fp = fopen($filepath, 'w');
             $ch = curl_init($url);
             curl_setopt($ch, CURLOPT_FILE, $fp);
             curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+            curl_setopt($ch, CURLOPT_USERAGENT, $user_agent);
             $success = curl_exec($ch) && curl_getinfo($ch, CURLINFO_HTTP_CODE) === 200;
             fclose($fp);
             curl_close($ch);


### PR DESCRIPTION
Picsum, like many sites, has begun returning 403 for requests without a user agent. curl_exec doesn't set a default user agent, even if one is set in php ini, so as it stands this library can no longer download images. This PR sets the curl user agent to the value set in php.ini with a fallback to a recent version of firefox, allowing image downloads again