### PR TITLE
Add support for static image URLs via seed string

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ $faker->addProvider(new \Smknstd\FakerPicsumImages\FakerPicsumImagesProvider($fa
 // return a string that contains a url like 'https://picsum.photos/800/600/'
 $faker->imageUrl(width: 800, height: 600); 
 
+// return a string that contains a url which returns the same random image based on the provided seed
+$filePath= $faker->image(width: 800, height: 800, seed: 'useremail@example.com');
+
 // download a properly sized image from picsum into a file with a file path like '/tmp/13b73edae8443990be1aa8f1a483bc27.jpg'
 $filePath= $faker->image(dir: '/tmp', width: 640, height: 480);
 ```
@@ -38,6 +41,7 @@ $filePath= $faker->image(dir: '/tmp', width: 640, height: 480);
 Also, there are some more options :
 - alternative webp format
 - effects (grayscale, blurry)
+- seeding ensures you can get the same photo each time by providing a seed string
 - returning a specific photo based on an id instead of a random one (ex: https://picsum.photos/id/1/800/600)
 
 ## Testing

--- a/src/FakerPicsumImagesProvider.php
+++ b/src/FakerPicsumImagesProvider.php
@@ -24,11 +24,15 @@ class FakerPicsumImagesProvider extends BaseProvider
         bool $randomize = true,
         bool $gray = false,
         int $blur = null,
-        string $imageExtension = null
+        string $imageExtension = null,
+        string $seed = null
     ): string {
         $url = '';
         if ($id) {
             $url = 'id/' . $id . '/';
+        }
+        if ($seed) {
+            $url .= 'seed/' . $seed . '/';
         }
         $url .= "{$width}/{$height}";
         $queryString = self::buildQueryString($gray, $blur, $randomize);
@@ -52,9 +56,10 @@ class FakerPicsumImagesProvider extends BaseProvider
         bool $randomize = true,
         bool $gray = false,
         int $blur = null,
-        string $imageExtension = null
+        string $imageExtension = null,
+        string $seed = null
     ): bool|\RuntimeException|string {
-        $url = static::imageUrl($width, $height, $id, $randomize, $gray, $blur, $imageExtension);
+        $url = static::imageUrl($width, $height, $id, $randomize, $gray, $blur, $imageExtension, $seed);
 
         return self::fetchImage($url, $dir, $isFullPath, $imageExtension ?? self::JPG_IMAGE);
     }

--- a/tests/FakerPicsumImagesProviderTest.php
+++ b/tests/FakerPicsumImagesProviderTest.php
@@ -27,6 +27,11 @@ class FakerPicsumImagesProviderTest extends TestCase
         $this->assertMatchesRegularExpression('#^https://picsum\.photos/800/400\?grayscale=#', FakerPicsumImagesProvider::imageUrl(800, 400, null, false, true));
     }
 
+    public function testImageUrlSeed()
+    {
+        $this->assertMatchesRegularExpression('#^https://picsum\.photos/seed/1234567/800/400#', FakerPicsumImagesProvider::imageUrl(800, 400, null, false, seed: '1234567'));
+    }
+
     public function testImageUrlWithIdAndCustomWidthAndHeight()
     {
         $this->assertMatchesRegularExpression('#^https://picsum.photos/id/871/800/400#', FakerPicsumImagesProvider::imageUrl(800, 400, 871));


### PR DESCRIPTION
This change allows you to specify a seed when building an image URL.  This ensures you get the same, consistent image for the seed provided.